### PR TITLE
Parsing: code improvements and bug fixing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,8 @@ CC		= c++
 CFLAGS	= -Wall -Wextra -Werror -Wshadow -std=c++20 -MMD -MP
 SRC		= src/main.cpp src/server.cpp src/listener.cpp src/client.cpp \
 		  src/error.cpp src/msg_parser.cpp src/sender.cpp src/numerics.cpp \
-		  src/parsing_utils.cpp src/commands.cpp src/registration.cpp
+		  src/parsing_utils.cpp src/commands.cpp src/registration.cpp \
+		  src/command_utils.cpp
 OBJS	= $(SRC:.cpp=.o)
 DEPS	= $(SRC:.cpp=.d)
 

--- a/lib/commands.hpp
+++ b/lib/commands.hpp
@@ -16,7 +16,7 @@ void	execute_USER_cmd(t_IRC_Client &client);
 void	execute_NICK_cmd(t_IRC_Client &client, t_IRC_Server &server);
 
 /* IRC Commands */
-void	execute_QUIT_cmd(t_IRC_Client &client); // WARN: work in progress
+void	execute_QUIT_cmd(t_IRC_Client &client, t_IRC_Server &server); // WARN: work in progress
 
 /* Bitmask check helpers */
 bool	has_provided_user_and_nick_names(t_bmask mask);

--- a/lib/commands.hpp
+++ b/lib/commands.hpp
@@ -4,6 +4,7 @@
 # include "irc_fatstruct.hpp"
 
 # include <unordered_map>
+# include <string>
 # include <string_view>
 
 /* Command handling dispatch */
@@ -27,5 +28,7 @@ bool	is_or_was_password_provided_first(const t_bmask state);
 bool	is_nick_already_in_use(const std::unordered_map<int, t_IRC_Client> &clients,
             const int fd, const std::string_view new_nick);
 bool	is_nickname_valid(const std::string_view nickname);
+void	append_client_quit_msg(std::string &buffer, const t_IRC_Client &quitter);
+void	append_nick_user_host(std::string &buffer, const t_IRC_Client &client);
 
 #endif

--- a/lib/irc_fatstruct.hpp
+++ b/lib/irc_fatstruct.hpp
@@ -8,7 +8,6 @@
 # include <vector>
 # include <new> // for hardware_constructive_interference_size
 # include <string_view>
-# include <cctype> // for std::isalnum()
 
 # define MAX_CLIENTS 128
 # define MAX_CHANNELS 64

--- a/lib/irc_fatstruct.hpp
+++ b/lib/irc_fatstruct.hpp
@@ -143,6 +143,27 @@ typedef struct	s_IRC_Client
 	// erasing string's beginning may require moving its tail to the front.
 	static constexpr size_t	offset_threshold = 8192;
 
+	// whitelist of allowed characters for clients' nickname
+	// Updating the allowed symbols in this array would carry over whole program.
+	static constexpr const std::string_view	nick_whitelist = {
+		"[]{}\\|#&:$%<>_-" // allowed symbols: can be modified safely.
+		"0123456789" // digits
+		"abcdefghijklmnopqrstuvwxyz" // lowercase alphabet
+		"ABCDEFGHIJKLMNOPQRSTUVWXYZ" // uppercase alphabet
+	};
+
+	// string_view into nick_whitelist's special symbol characters, allows to
+	// send those allowed symbols to clients, if they choose an erroneous nickname
+	static constexpr std::string_view	allowed_symbols_nick = [] {
+		size_t	cap = nick_whitelist.size();
+		size_t	i = 0;
+
+		while (i < cap && nick_whitelist[i] != '0')
+			++i;
+
+		return (std::string_view{nick_whitelist.data(), i});
+	}();
+
 	t_bmask				state;
 	struct sockaddr_in	addr;  //all the adress data. We'll trim it down as needed.
 	int					fd;
@@ -166,9 +187,9 @@ static_assert(sizeof(t_IRC_Client) <= 68*CACHE_LINE_SIZE," t_IRC_Client did not 
 typedef struct	s_IRC_Server
 {
 	t_bmask									state; //Not in use in this version
-	static constexpr const char				name[] = "humble_server";
+	static constexpr const char				*name = "humble_server";
 	static constexpr int					poll_timeout = 1000;
-	static constexpr const char				version[] = "0.042"; // remember to update when upgrading ;-)
+	static constexpr const char				*version = "0.042"; // remember to update when upgrading ;-)
 	int										listen_fd;
 	int										port;
 	std::string_view						password;

--- a/lib/irc_fatstruct.hpp
+++ b/lib/irc_fatstruct.hpp
@@ -59,12 +59,12 @@ typedef struct	s_IRC_Channel
 	std::string					topic;
 	std::string					key;
 	int							user_limit;
-	t_IRC_ChannelMembership*	members;
+	t_IRC_ChannelMembership		members[MAX_CLIENTS]; // another option is to have a pointer
 	// FIXME: ADD AN INT ARRAY FD of size clients_max macro - and a length. All fds connected to that channel will be in the array, and we update it as we go.
-	int							member_fds[MAX_CLIENTS]; // WARN: can we remove some of the other members from this struct, now that we have this array?
+	int							member_fds[MAX_CLIENTS]; // WARN: can we remove some of the other elements from this struct, now that we have this array?
 	int							member_count;
 }								t_IRC_Channel;
-static_assert(sizeof(t_IRC_Channel) <= 10*CACHE_LINE_SIZE," t_IRC_Channel did not use 10 cache line" );
+static_assert(sizeof(t_IRC_Channel) <= 42*CACHE_LINE_SIZE," t_IRC_Channel did not use 42 cache line" );
 
 typedef struct	s_parser
 {
@@ -97,10 +97,7 @@ typedef struct	s_parser
 	* we could have as many as 254-255 arguments. */
 	static constexpr size_t		buf_size = 512;
 	static constexpr size_t		max_params = 255;
-	// WARN: adapt to longest available Command in 'commands'. Currently it is: "PRIVMSG" -- or delete this entirely if we are allowed to keep the lambda logic following this!
-	// static constexpr size_t		longest_cmd_size = sizeof("PRIVMSG") - 1; delete this if the following is okay.
 
-	// FIXME: Are we allowed to have this lambda logic in the header?
 	// Computes the longest available command's length at compile time, so that
 	// future changes in the command list would adjust this value automatically.
 	static constexpr size_t		longest_cmd_size = [] {

--- a/lib/irc_fatstruct.hpp
+++ b/lib/irc_fatstruct.hpp
@@ -150,7 +150,7 @@ typedef struct	s_IRC_Client
 	char				nick_buf[max_nicklen]; // not nullterminated, use 'nick' instead
 	std::string			username;
 	std::string			realname;
-	char				hostname[INET_ADDRSTRLEN];
+	char				hostname[INET_ADDRSTRLEN]; // This array is null terminated when initialized by inet_ntop(). Change macro to 'INET6_ADDRSTRLEN' if server ever switches to TCP6 ('AF_INET6').
 	std::string			received_message_buffer;
 	std::string			send_message_buffer;
 	size_t				send_offset;

--- a/lib/irc_fatstruct.hpp
+++ b/lib/irc_fatstruct.hpp
@@ -134,6 +134,10 @@ typedef struct	s_IRC_Client
 	// "If <nickname> is longer than the server allows (...), it is silently truncated"
 	static constexpr size_t	max_nicklen = 30;
 
+	// Allows reducing calls to std::string.erase() for the output buffer, since
+	// erasing string's beginning may require moving its tail to the front.
+	static constexpr size_t	offset_threshold = 8192;
+
 	t_bmask				state;
 	struct sockaddr_in	addr;  //all the adress data. We'll trim it down as needed.
 	int					fd;
@@ -144,6 +148,7 @@ typedef struct	s_IRC_Client
 	char				hostname[INET_ADDRSTRLEN];
 	std::string			received_message_buffer;
 	std::string			send_message_buffer;
+	size_t				send_offset;
 	t_parser			parser;
 	t_IRC_Channel*		joined_channels;
 	int					joined_count;

--- a/lib/irc_fatstruct.hpp
+++ b/lib/irc_fatstruct.hpp
@@ -68,7 +68,7 @@ static_assert(sizeof(t_IRC_Channel) <= 10*CACHE_LINE_SIZE," t_IRC_Channel did no
 
 typedef struct	s_parser
 {
-	static constexpr const char	*commands[] = {
+	static constexpr std::string_view	commands[] = {
 		"PASS",
 		"NICK",
 		"USER",
@@ -88,12 +88,7 @@ typedef struct	s_parser
 	// NOTE: do not implement OPER: we need channel operators, not IRC operators.
 	// WARN: do we need to implement CAP? Is that what allows a user to become operator?
 
-	static constexpr size_t		n_valid_cmds = sizeof(commands) / sizeof(char *);
-	/* eventual PREFIX implementations */
-	// t_bmask			state;
-	//std::string_view	tags; // eventual tokens
-	//std::string_view	source; // eventual tokens
-	// WARN: is this used?
+	static constexpr size_t		n_valid_cmds = sizeof(commands) / sizeof(std::string_view);
 
 	/* NOTE: max_params is currently set to 255, because the longest message the
 	* server accepts is 512 bytes long, the last of which is either '\n' or "\r\n".
@@ -102,8 +97,21 @@ typedef struct	s_parser
 	* we could have as many as 254-255 arguments. */
 	static constexpr size_t		buf_size = 512;
 	static constexpr size_t		max_params = 255;
-	static constexpr size_t		longest_cmd_size = sizeof("PRIVMSG") - 1;
-	// WARN: adapt to longest available Command in 'commands'. Currently it is: "PRIVMSG"
+	// WARN: adapt to longest available Command in 'commands'. Currently it is: "PRIVMSG" -- or delete this entirely if we are allowed to keep the lambda logic following this!
+	// static constexpr size_t		longest_cmd_size = sizeof("PRIVMSG") - 1; delete this if the following is okay.
+
+	// FIXME: Are we allowed to have this lambda logic in the header?
+	// Computes the longest available command's length at compile time, so that
+	// future changes in the command list would adjust this value automatically.
+	static constexpr size_t		longest_cmd_size = [] {
+		size_t len = 0;
+		for (size_t i = 0; i < n_valid_cmds; ++i)
+		{
+			if (len < commands[i].size())
+				len = commands[i].size();
+		}
+		return len;
+	}();
 
 	size_t				n_params; // the 'trailing' parameter is not split into differnet fields, and counts as 1
 	std::string_view	verb;

--- a/lib/irc_fatstruct.hpp
+++ b/lib/irc_fatstruct.hpp
@@ -8,6 +8,7 @@
 # include <vector>
 # include <new> // for hardware_constructive_interference_size
 # include <string_view>
+# include <cctype> // for std::isalnum()
 
 # define MAX_CLIENTS 128
 # define MAX_CHANNELS 64
@@ -155,10 +156,10 @@ typedef struct	s_IRC_Client
 	// string_view into nick_whitelist's special symbol characters, allows to
 	// send those allowed symbols to clients, if they choose an erroneous nickname
 	static constexpr std::string_view	allowed_symbols_nick = [] {
-		size_t	cap = nick_whitelist.size();
 		size_t	i = 0;
 
-		while (i < cap && nick_whitelist[i] != '0')
+		while (i < nick_whitelist.size() &&
+				(nick_whitelist[i] < '0' || nick_whitelist[i] > '9'))
 			++i;
 
 		return (std::string_view{nick_whitelist.data(), i});

--- a/lib/parser.hpp
+++ b/lib/parser.hpp
@@ -24,6 +24,8 @@ void	tokenize_message(t_IRC_Client &client, const std::string_view msg);
 int		init_password(const char *src, std::string_view &dest);
 ssize_t	strlen_printable_no_spaces(const char *str);
 char	to_uppercase(char c);
+size_t	skip_leading_spaces_and_check_for_empty_message(const std::string &buf,
+            const size_t pos, const bool has_carriage_return);
 bool	are_equal_strs_case_insensitive(const char *str1, const size_t len1,
             const char *str2, const size_t len2);
 

--- a/lib/parser.hpp
+++ b/lib/parser.hpp
@@ -25,7 +25,7 @@ int		init_password(const char *src, std::string_view &dest);
 ssize_t	strlen_printable_no_spaces(const char *str);
 char	to_uppercase(char c);
 size_t	skip_leading_spaces_and_check_for_empty_message(const std::string &buf,
-            const size_t pos, const bool has_carriage_return);
+            const size_t pos, const bool has_cr);
 bool	are_equal_strs_case_insensitive(const char *str1, const size_t len1,
             const char *str2, const size_t len2);
 

--- a/src/client.cpp
+++ b/src/client.cpp
@@ -35,9 +35,6 @@ void	handle_client_message(t_IRC_Client &client, t_IRC_Server &server)
 				build_ERR_INPUTTOOLONG(client);
 			} catch (const std::exception &e) {
 				log_error(e.what(), __FILE__, __LINE__, 1);
-				// WARN: Append error message to be sent to the client/ to all clients,
-				// and make sure that they receive it before shutting down?
-				// Or is it overkill in this case?
 				requested_shutdown = 1;
 				return;
 			}
@@ -51,9 +48,6 @@ void	handle_client_message(t_IRC_Client &client, t_IRC_Server &server)
 				dispatch_client_command(client, server);
 			} catch (const std::exception &e) {
 				log_error(e.what(), __FILE__, __LINE__, 1);
-				// WARN: Append error message to be sent to the client/ to all clients,
-				// and make sure that they receive it before shutting down?
-				// Or is it overkill in this case?
 				requested_shutdown = 1;
 				return;
 			}
@@ -66,9 +60,6 @@ void	handle_client_message(t_IRC_Client &client, t_IRC_Server &server)
 			build_ERR_INPUTTOOLONG(client);
 		} catch (const std::exception &e) {
 			log_error(e.what(), __FILE__, __LINE__, 1);
-			// WARN: Append error message to be sent to the client/ to all clients,
-			// and make sure that they receive it before shutting down?
-			// Or is it overkill in this case?
 			requested_shutdown = 1;
 			return;
 

--- a/src/client.cpp
+++ b/src/client.cpp
@@ -24,6 +24,7 @@ bool	recv_from_client(t_IRC_Server &server, int fd)
 	return false;
 }
 
+// WARN: Add try-catch block/s to handle potential exceptions from std::string's clear() and erase()
 void	handle_client_message(t_IRC_Client &client, t_IRC_Server &server)
 {
 	std::string	&buf = client.received_message_buffer;

--- a/src/client.cpp
+++ b/src/client.cpp
@@ -33,21 +33,6 @@ void	handle_client_message(t_IRC_Client &client, t_IRC_Server &server)
 	{
 		if (buf[pos] == '\0') // a null-terminator was found in the message, unexpected
 		{
-			// WARN: just temporary:
-			std::cout << "Invalid IRC message, because null terminator was detected\n";
-			std::cout << "Buffer holds: \n\t<";
-
-			for (char c : buf ) {
-
-				if (c == '\0')
-					std::cout << "\\0";
-				else
-					std::cout << c;
-
-			}
-			std::cout << "\n\n";
-			// WARN: just temporary for debugging...
-
 			// handle the rest of the malformed message accordingly,
 			// silently ignoring the message up to the next newline
 			pos = buf.find('\n', pos);

--- a/src/client.cpp
+++ b/src/client.cpp
@@ -1,5 +1,6 @@
 #include <iostream>
 #include <exception>
+#include <string_view>
 #include "../lib/irc_fatstruct.hpp"
 #include "../lib/server.hpp"
 #include "../lib/parser.hpp"
@@ -27,8 +28,39 @@ void	handle_client_message(t_IRC_Client &client, t_IRC_Server &server)
 {
 	std::string	&buf = client.received_message_buffer;
 	size_t		pos = std::string::npos;
-	while ((pos = buf.find('\n')) != std::string::npos)
+
+	while((pos = buf.find_first_of(std::string_view{"\n\0", 2})) != std::string::npos)
 	{
+		if (buf[pos] == '\0') // a null-terminator was found in the message, unexpected
+		{
+			// WARN: just temporary:
+			std::cout << "Invalid IRC message, because null terminator was detected\n";
+			std::cout << "Buffer holds: \n\t<";
+
+			for (char c : buf ) {
+
+				if (c == '\0')
+					std::cout << "\\0";
+				else
+					std::cout << c;
+
+			}
+			std::cout << "\n\n";
+			// WARN: just temporary for debugging...
+
+			// handle the rest of the malformed message accordingly,
+			// silently ignoring the message up to the next newline
+			pos = buf.find('\n');
+			if (pos == std::string::npos)
+			{
+				client.state |= t_IRC_Client::DISCARD_MSG;
+				buf.clear();
+			}
+			else
+				buf.erase(0, pos + 1);
+			return;
+		}
+
 		if (parse_message(pos, buf, client) == -1)
 		{
 			try {

--- a/src/client.cpp
+++ b/src/client.cpp
@@ -50,15 +50,18 @@ void	handle_client_message(t_IRC_Client &client, t_IRC_Server &server)
 
 			// handle the rest of the malformed message accordingly,
 			// silently ignoring the message up to the next newline
-			pos = buf.find('\n');
+			pos = buf.find('\n', pos);
 			if (pos == std::string::npos)
 			{
 				client.state |= t_IRC_Client::DISCARD_MSG;
 				buf.clear();
+				return;
 			}
 			else
+			{
 				buf.erase(0, pos + 1);
-			return;
+				continue;
+			}
 		}
 
 		if (parse_message(pos, buf, client) == -1)

--- a/src/client.cpp
+++ b/src/client.cpp
@@ -26,9 +26,8 @@ bool	recv_from_client(t_IRC_Server &server, int fd)
 void	handle_client_message(t_IRC_Client &client, t_IRC_Server &server)
 {
 	std::string	&buf = client.received_message_buffer;
-	size_t		pos = buf.find('\n');
-
-	if (pos != std::string::npos)
+	size_t		pos = std::string::npos;
+	while ((pos = buf.find('\n')) != std::string::npos)
 	{
 		if (parse_message(pos, buf, client) == -1)
 		{
@@ -60,9 +59,8 @@ void	handle_client_message(t_IRC_Client &client, t_IRC_Server &server)
 			}
 		}
 		buf.erase(0, pos + 1);
-
 	}
-	else if (buf.length() >= t_parser::buf_size) // WARN: maybe this should be 'if', not 'else if'; but this might be good enough, since the buffer is cleared up from long input
+	if (buf.length() >= t_parser::buf_size)
 	{
 		try {
 			build_ERR_INPUTTOOLONG(client);

--- a/src/command_utils.cpp
+++ b/src/command_utils.cpp
@@ -1,0 +1,24 @@
+#include "../lib/irc_fatstruct.hpp"
+#include "../lib/commands.hpp"
+
+#include <string>
+
+// this function may throw
+void	append_client_quit_msg(std::string &buffer, const t_IRC_Client &quitter)
+{
+	append_nick_user_host(buffer, quitter);
+	buffer += " QUIT :Quit: ";
+	if (quitter.parser.n_params)
+		buffer += quitter.parser.params[0];
+	buffer += "\r\n";
+}
+
+// this function may throw
+void	append_nick_user_host(std::string &buffer, const t_IRC_Client &client)
+{
+	buffer += client.nick;
+	buffer += '!';
+	buffer += client.username;
+	buffer += '@';
+	buffer += client.hostname;
+}

--- a/src/commands.cpp
+++ b/src/commands.cpp
@@ -6,6 +6,9 @@
 #include <cstring> // for std::strncmp()
 #include <string_view>
 
+// WARN: To avoid bad invalid memory access surprises: Once PRIVMSG is implemented,
+// Test something like: "PRIVMSG :some message" followed by "PRIVMSS :whatever".
+
 void	dispatch_client_command(t_IRC_Client &client, t_IRC_Server &server)
 {
 	char	*verb_in_caps = client.parser.verb_in_caps;
@@ -19,7 +22,8 @@ void	dispatch_client_command(t_IRC_Client &client, t_IRC_Server &server)
 
 		for (i = 0; i < t_parser::n_valid_cmds; ++i)
 		{
-			if (!std::strncmp(t_parser::commands[i], verb_in_caps, verb_len))
+			if (verb_len == t_parser::commands[i].size() &&
+					!std::strncmp(t_parser::commands[i].data(), verb_in_caps, verb_len))
 				break ;
 		}
 	}

--- a/src/commands.cpp
+++ b/src/commands.cpp
@@ -76,16 +76,23 @@ void	execute_QUIT_cmd(t_IRC_Client &client, t_IRC_Server &server)
 	// optional feature:
 	// assemble message to be sent to every single client that is on the same channel/s
 	// as the disconnecting client, informing them of their peer's leave
-	// WARN: just work in progress...
+	// WARN: just work in progress... Maybe there could be a way to not walk through
+	// all of the clients, but rather pinpoint the clients of the channel/s that
+	// the quitting client was connected to, and only walk those clients, in a more
+	// efficient manner?
+
+	// WARN: Make sure that if a fellow client shares more than one channel
+	// membership with the quitting client, they would not get this message from
+	// the server more than once!
+
 	for (std::unordered_map<int, t_IRC_Client>::iterator iterator = server.clients.begin();
 		!requested_shutdown && iterator != server.clients.end(); ++iterator)
 	{
 		if (client.fd == iterator->second.fd) // no need to send message to the disconnecting client
 			continue;
 
-		// append_client_has_quit_message(iterator->second.send_message_buffer);
-		// client.buffer += "?????"
-
+		// TODO: check if the user is on at least one shared channel with the client.
+		append_client_quit_msg(iterator->second.send_message_buffer, client);
 	}
 
 	// set the disconnect flag

--- a/src/commands.cpp
+++ b/src/commands.cpp
@@ -2,6 +2,7 @@
 #include "../lib/commands.hpp"
 #include "../lib/numerics.hpp"
 #include "../lib/parser.hpp"
+#include "../lib/server.hpp"
 
 #include <cstring> // for std::strncmp()
 #include <string_view>
@@ -50,7 +51,7 @@ void	dispatch_client_command(t_IRC_Client &client, t_IRC_Server &server)
 			case 0:  execute_PASS_cmd(client, server); break;
 			case 1:  execute_NICK_cmd(client, server); break;
 			case 2:  execute_USER_cmd(client);         break;
-			case 3:  execute_QUIT_cmd(client);         break;
+			case 3:  execute_QUIT_cmd(client, server); break;
 			// case 4:  execute_JOIN_cmd(client);         break;
 			// case 5:  execute_PART_cmd(client);         break;
 			// case 6:  execute_PRIVMSG_cmd(client);      break;
@@ -69,17 +70,23 @@ void	dispatch_client_command(t_IRC_Client &client, t_IRC_Server &server)
 }
 
 // WARN: work in progress
-void	execute_QUIT_cmd(t_IRC_Client &client)
+void	execute_QUIT_cmd(t_IRC_Client &client, t_IRC_Server &server)
 {
-	// TODO:
-	// assemble reply ERROR message (follow modern Horse documentation for 'QUIT message')
-
-
 	// TODO:
 	// optional feature:
 	// assemble message to be sent to every single client that is on the same channel/s
 	// as the disconnecting client, informing them of their peer's leave
+	// WARN: just work in progress...
+	for (std::unordered_map<int, t_IRC_Client>::iterator iterator = server.clients.begin();
+		!requested_shutdown && iterator != server.clients.end(); ++iterator)
+	{
+		if (client.fd == iterator->second.fd) // no need to send message to the disconnecting client
+			continue;
 
+		// append_client_has_quit_message(iterator->second.send_message_buffer);
+		// client.buffer += "?????"
+
+	}
 
 	// set the disconnect flag
 	client.state |= t_IRC_Client::DISCONNECT;

--- a/src/commands.cpp
+++ b/src/commands.cpp
@@ -6,6 +6,7 @@
 
 #include <cstring> // for std::strncmp()
 #include <string_view>
+#include <unordered_map>
 
 // WARN: To avoid bad invalid memory access surprises: Once PRIVMSG is implemented,
 // Test something like: "PRIVMSG :some message" followed by "PRIVMSS :whatever".
@@ -85,6 +86,10 @@ void	execute_QUIT_cmd(t_IRC_Client &client, t_IRC_Server &server)
 	// membership with the quitting client, they would not get this message from
 	// the server more than once!
 
+	// WARN: Just a placeholder: This would send a notification to ALL clients
+	// but the quitting client, about that client's leave. It should only be
+	// done to all fellow channelers - as part of the IRC protocol - but channel
+	// system is not yet in place.
 	for (std::unordered_map<int, t_IRC_Client>::iterator iterator = server.clients.begin();
 		!requested_shutdown && iterator != server.clients.end(); ++iterator)
 	{

--- a/src/msg_parser.cpp
+++ b/src/msg_parser.cpp
@@ -31,28 +31,19 @@ int	parse_message(const size_t pos, const std::string &buf, t_IRC_Client &client
 	}
 
 	// scan for carriage return (IRC message may end with '\n' or "\r\n")
-	bool	has_carriage_return = 0;
+	bool	has_cr = 0;
 	if (pos >= 1 && buf[pos - 1] == '\r')
-		has_carriage_return = 1;
+		has_cr = 1;
 
-	// Move index i to the first character which is not a space.
-	// This allows identifying a string containing only spaces and ignore it,
-	// and also skipping leading spaces and treating the first token appropriately.
-	size_t	i = 0;
-	while (buf[i] == ' ' && i < pos)
-		++i;
-
-	// Check whether client sent an empty message or a message containing only spaces.
-	// such a message is to be ignored (without sending any reply),
-	// according to the IRC protocol.
-	if (!pos || (pos == 1 && has_carriage_return) || (i == pos - has_carriage_return))
+	size_t i = skip_leading_spaces_and_check_for_empty_message(buf, pos, has_cr);
+	if (i == std::string::npos)
 	{
 		client.state |= t_IRC_Client::DISCARD_MSG;
 		return (0);
 	}
 
-	// Candidate message detected: send string_view for parsing.
-	tokenize_message(client, std::string_view{&buf[i], pos - i - has_carriage_return});
+	// Candidate message detected: send first message in buffer for tokenizing
+	tokenize_message(client, std::string_view{&buf[i], pos - i - has_cr});
 	return (0);
 }
 

--- a/src/msg_parser.cpp
+++ b/src/msg_parser.cpp
@@ -35,9 +35,9 @@ int	parse_message(const size_t pos, const std::string &buf, t_IRC_Client &client
 	if (pos >= 1 && buf[pos - 1] == '\r')
 		has_carriage_return = 1;
 
-	// Move index i to the first character which is not a space
+	// Move index i to the first character which is not a space.
 	// This allows identifying a string containing only spaces and ignore it,
-	// but also to skip leading spaces and parse the command appropriately.
+	// and also skipping leading spaces and treating the first token appropriately.
 	size_t	i = 0;
 	while (buf[i] == ' ' && i < pos)
 		++i;

--- a/src/msg_parser.cpp
+++ b/src/msg_parser.cpp
@@ -3,6 +3,7 @@
 // with 'nc'?), and inputting something and then ctrl + d twice in a row just
 // completely seems to break the server? This needs more testing. Is it SIGPIPE?
 
+// FIXME: delete this warning if you end up handling the null-terminators here.
 // WARN: Should the parser check for null-terminators - that are not 'supposed'
 // to be sent by an IRC client, but that may still be sent, as part of an attack
 // for example?

--- a/src/msg_parser.cpp
+++ b/src/msg_parser.cpp
@@ -35,17 +35,24 @@ int	parse_message(const size_t pos, const std::string &buf, t_IRC_Client &client
 	if (pos >= 1 && buf[pos - 1] == '\r')
 		has_carriage_return = 1;
 
-	// Check whether client sent an empty message:
+	// Move index i to the first character which is not a space
+	// This allows identifying a string containing only spaces and ignore it,
+	// but also to skip leading spaces and parse the command appropriately.
+	size_t	i = 0;
+	while (buf[i] == ' ' && i < pos)
+		++i;
+
+	// Check whether client sent an empty message or a message containing only spaces.
 	// such a message is to be ignored (without sending any reply),
 	// according to the IRC protocol.
-	if (!pos || (pos == 1 && has_carriage_return))
+	if (!pos || (pos == 1 && has_carriage_return) || (i == pos - has_carriage_return))
 	{
 		client.state |= t_IRC_Client::DISCARD_MSG;
 		return (0);
 	}
 
 	// Candidate message detected: send string_view for parsing.
-	tokenize_message(client, std::string_view{&buf[0], pos - has_carriage_return});
+	tokenize_message(client, std::string_view{&buf[i], pos - i - has_carriage_return});
 	return (0);
 }
 

--- a/src/numerics.cpp
+++ b/src/numerics.cpp
@@ -137,14 +137,15 @@ void	build_ERR_ERRONEOUSNICKNAME(t_IRC_Client &client,
 {
 	// WARN: is the last parameter too long? Check IRC documentation regarding
 	// length of server-client messages.
-	// WARN: update all allowed symbols if they change!
 
 	std::string	&buffer = client.send_message_buffer;
 
 	append_common_reply_prefix(buffer, "432", client.nick);
 	buffer += new_nick;
 	buffer += " :Erroneous nickname. Accepted characters: alphabetical "
-		"letters, digits, and the following symbols: \"[]{}\\|#&:$%<>_-\". "
+		"letters, digits, and the following symbols: \"";
+	buffer += t_IRC_Client::allowed_symbols_nick;
+	buffer += "\". "
 		"First characters may not be: a digit, '#', ':' or \"&#\". "
 		"Only the first 30 characters will be considered.\r\n";
 }

--- a/src/numerics.cpp
+++ b/src/numerics.cpp
@@ -4,8 +4,8 @@
 #include <string>
 #include <string_view>
 
-static void	append_common_reply_prefix(std::string &buffer, const char *numeric,
-                const std::string_view nick);
+void	append_common_reply_prefix(std::string &buffer,
+            const std::string_view numeric, const std::string_view nick);
 
 // NOTE: From the modern documentation, regarding numeric replies:
 // "Most messages sent from a client to a server generates a reply of some sort.
@@ -227,11 +227,11 @@ void	build_ERR_PASSWDMISMATCH(t_IRC_Client &client)
 	buffer += ":Password incorrect\r\n";
 }
 
-void	append_common_reply_prefix(std::string &buffer, const char *numeric,
-            const std::string_view nick)
+void	append_common_reply_prefix(std::string &buffer,
+            const std::string_view numeric, const std::string_view nick)
 {
 	buffer += ':';
-	buffer += (t_IRC_Server::name);
+	buffer += t_IRC_Server::name;
 	buffer += ' ';
 	buffer += numeric;
 	buffer += ' ';

--- a/src/parsing_utils.cpp
+++ b/src/parsing_utils.cpp
@@ -1,6 +1,7 @@
 #include "../lib/parser.hpp"
 
 #include <cctype> // for std::toupper() & std::iscntrl()
+#include <string>
 #include <string_view>
 
 int	init_password(const char *src, std::string_view &dest)
@@ -37,6 +38,25 @@ char	to_uppercase(char c)
 		static_cast<char>(std::toupper(static_cast<unsigned char>(c)));
 
 	return (result);
+}
+
+size_t	skip_leading_spaces_and_check_for_empty_message(const std::string &buf,
+            const size_t pos, const bool has_carriage_return)
+{
+	size_t	i = 0;
+
+	// skip leading spaces
+	while (i < pos && buf[i] == ' ')
+		++i;
+
+	/* returns true if the first message in the buffer is empty (i.e. containing only):
+	* • '\n'
+	* • "\r\n"
+	* • spaces culminating with '\n' or "\r\n" */
+	if (i == pos - has_carriage_return)
+		return (std::string::npos);
+
+	return i;
 }
 
 bool	are_equal_strs_case_insensitive(const char *str1, const size_t len1,

--- a/src/parsing_utils.cpp
+++ b/src/parsing_utils.cpp
@@ -50,9 +50,9 @@ size_t	skip_leading_spaces_and_check_for_empty_message(const std::string &buf,
 		++i;
 
 	/* returns true if the first message in the buffer is empty (i.e. containing only):
-	* • '\n'
-	* • "\r\n"
-	* • spaces culminating with '\n' or "\r\n" */
+	* • LF ('\n')
+	* • CRLF ("\r\n")
+	* • spaces culminating with LF or CRLF */
 	if (i == pos - has_carriage_return)
 		return (std::string::npos);
 

--- a/src/parsing_utils.cpp
+++ b/src/parsing_utils.cpp
@@ -41,7 +41,7 @@ char	to_uppercase(char c)
 }
 
 size_t	skip_leading_spaces_and_check_for_empty_message(const std::string &buf,
-            const size_t pos, const bool has_carriage_return)
+            const size_t pos, const bool has_cr)
 {
 	size_t	i = 0;
 
@@ -53,7 +53,7 @@ size_t	skip_leading_spaces_and_check_for_empty_message(const std::string &buf,
 	* • LF ('\n')
 	* • CRLF ("\r\n")
 	* • spaces culminating with LF or CRLF */
-	if (i == pos - has_carriage_return)
+	if (i == pos - has_cr)
 		return (std::string::npos);
 
 	return i;

--- a/src/registration.cpp
+++ b/src/registration.cpp
@@ -325,9 +325,7 @@ bool	is_nickname_valid(const std::string_view nickname)
 	if (len > 1 && nickname.compare(0, 2, "&#") == 0)
 		return false;
 
-	if (nickname.find_first_not_of("[]{}\\|#&:$%<>_-1234567890"
-			"abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ")
-			!= std::string_view::npos)
+	if (nickname.find_first_not_of(t_IRC_Client::nick_whitelist) != std::string_view::npos)
 		return false;
 	return true;
 }

--- a/src/registration.cpp
+++ b/src/registration.cpp
@@ -99,10 +99,6 @@ void	client_registration(t_IRC_Client &client, const size_t i, t_IRC_Server &ser
 			// send ERROR ?
 
 
-			// WARN: for now, this flag update is fine. But when we introduce the
-			// queue system for sending replies to the client: Shouldn't the client
-			// FIRST receive the error messages, and only then be disconnected?
-
 			// set disconnect flag
 			client.state |= t_IRC_Client::DISCONNECT;
 		}

--- a/src/registration.cpp
+++ b/src/registration.cpp
@@ -62,7 +62,7 @@ void	client_registration(t_IRC_Client &client, const size_t i, t_IRC_Server &ser
 		case 0: execute_PASS_cmd(client, server); break;
 		case 1: execute_NICK_cmd(client, server); break;
 		case 2: execute_USER_cmd(client);         break;
-		case 3: execute_QUIT_cmd(client);         break;
+		case 3: execute_QUIT_cmd(client, server); break;
 	}
 
 	if (has_provided_user_and_nick_names(client.state))

--- a/src/registration.cpp
+++ b/src/registration.cpp
@@ -10,6 +10,7 @@
 #include <exception>
 #include <string> // for std::string's append()
 #include <algorithm> // for std::min()
+#include <cctype> // for std::isdigit()
 
 // TODO: Add the time checks!
 // Perhaps add some timer machine to t_IRC_Client (per client);
@@ -318,7 +319,7 @@ bool	is_nickname_valid(const std::string_view nickname)
 	if (len)
 	{
 		char	c = nickname[0];
-		if (std::isdigit(c) || c == '#' || c == ':')
+		if (std::isdigit(static_cast<unsigned char>(c)) || c == '#' || c == ':')
 			return false;
 	}
 	if (len > 1 && nickname.compare(0, 2, "&#") == 0)

--- a/src/sender.cpp
+++ b/src/sender.cpp
@@ -57,6 +57,7 @@ void	send_messages_to_all_clients(t_IRC_Server &server)
 				return;
 			}
 		}
+		// WARN: Is it 100% OK not to handle ret == 0?
 		try {
 			update_send_buffer_and_offset(send_buf, client.send_offset, ret);
 		} catch (const std::exception &e) {

--- a/src/sender.cpp
+++ b/src/sender.cpp
@@ -1,79 +1,94 @@
 #include "../lib/irc_fatstruct.hpp"
 #include "../lib/server.hpp"
 
-#include <sys/socket.h>
-#include <unistd.h> // for close()
-#include <unordered_map>
-#include <vector> // for std::erase_if()
+#include <sys/socket.h> // for send()
+#include <vector> // for the poll_fds vector
 #include <string>
 #include <cstring> // for std::strerror()
 #include <cerrno>
-#include <iostream>
 #include <exception>
 
-static void	disconnect_client_during_iterator_walk(t_IRC_Server &server,
-                std::unordered_map<int, t_IRC_Client>::iterator &iterator);
 static void	update_send_buffer_and_offset(std::string &send_buf, size_t &offset,
                 const size_t sent_bytes);
 
 void	send_messages_to_all_clients(t_IRC_Server &server)
 {
-	ssize_t	ret;
-
-	for (std::unordered_map<int, t_IRC_Client>::iterator iterator = server.clients.begin();
-		iterator != server.clients.end() && !requested_shutdown; )
+	for (size_t i = 0; i < server.poll_fds.size(); )
 	{
-		t_IRC_Client	&client = iterator->second;
-		std::string		&send_buf = client.send_message_buffer;
-		if (client.send_offset >= send_buf.size()) // no bytes to send to this client
+		if (server.listen_fd == server.poll_fds[i].fd)
 		{
-			if (!is_flag_set(client.state, t_IRC_Client::DISCONNECT))
-				++iterator;
-			else
-				disconnect_client_during_iterator_walk(server, iterator);
+			++i;
 			continue;
 		}
-		ret = send(client.fd, send_buf.c_str() + client.send_offset,
-			 send_buf.size() - client.send_offset, 0);
-		if (ret == -1)
+		t_IRC_Client	&client = server.clients[server.poll_fds[i].fd];
+		std::string		&send_buf = client.send_message_buffer;
+
+		if (client.send_offset >= send_buf.size()) // no bytes to send to this client
 		{
-			log_error(std::strerror(errno), __FILE__, __LINE__, 0);
-			if (errno == EPIPE) // WARN: for this to work, signal handler should ignore SIGPIPE, or the sockets should use some flag for it
-			{
-				// FIXME: SIGPIPE is not being ignored right now, so if a SIGPIPE
-				// occurs during send(), the program would terminate and would
-				// not be able to check the return value of send().
-				// SIGPIPE is a signal triggered by writing to a broken pipe/socket
-				// if that signal is ignored (either by the global signal handler
-				// or by some socket flags), the kernel instead reports the error via:
-				// send() → -1
-				// errno = EPIPE
-				disconnect_client_during_iterator_walk(server, iterator);
-				continue;
-			}
+			if (is_flag_set(client.state, t_IRC_Client::DISCONNECT))
+				disconnect_client(server, client.fd);
 			else
+				++i;
+			continue;
+		}
+		if (is_flag_set(server.poll_fds[i].revents, POLLOUT)) // check whether the fd is available for writing.
+		{
+			ssize_t	ret = send(client.fd, send_buf.c_str() + client.send_offset,
+				 send_buf.size() - client.send_offset, MSG_NOSIGNAL);
+			if (ret == -1)
 			{
+				if (errno == EPIPE)
+				{
+					/* The MSG_NOSIGNAL flag tells send() to avoid writing to
+					 * the socket if it is broken - which would trigger SIGPIPE
+					 * and, if that single is not handled, terminate the program.
+					 * In that case, send() returns -1 and sets errno to EPIPE */
+					log_error(std::strerror(errno), __FILE__, __LINE__, 0);
+					disconnect_client(server, client.fd);
+					continue;
+				}
+				else if (errno == EWOULDBLOCK)
+				{
+					// WARN: This check might be an issue, because of evaluation
+					// sheet bullet point that could be misinterpreted...
+					// Discuss this with the team on Thursday.
+
+					// identical to EAGAIN.
+					// This occurs for non-blocking sockets, "if space is not available
+					// at the sending socket to hold the message to be transmitted",
+					// (from 'man 3 send')
+					++i;
+					continue;
+				}
+				else
+				{
+					log_error(std::strerror(errno), __FILE__, __LINE__, 0);
+					requested_shutdown = 1;
+					return;
+				}
+			}
+			try {
+				update_send_buffer_and_offset(send_buf, client.send_offset, ret);
+			} catch (const std::exception &e) {
+				log_error(e.what(), __FILE__, __LINE__, 1);
+				// WARN: Should an error message be sent to all clients? This exception
+				// is most probably an std::bad_alloc, which is fatal...
 				requested_shutdown = 1;
 				return;
 			}
 		}
-		// WARN: Is it 100% OK not to handle ret == 0?
-		try {
-			update_send_buffer_and_offset(send_buf, client.send_offset, ret);
-		} catch (const std::exception &e) {
-			log_error(e.what(), __FILE__, __LINE__, 1);
-			// WARN: Should an error message be sent to all clients? This exception
-			// is most probably an std::bad_alloc, which is fatal...
-			requested_shutdown = 1;
-			return;
-		}
+		if (client.send_offset < send_buf.size()) // indicate that we need to write to the client
+			server.poll_fds[i].events |= POLLOUT;
+		else
+			server.poll_fds[i].events &= ~POLLOUT;
+
 		if (is_flag_set(client.state, t_IRC_Client::DISCONNECT)
 			&& client.send_offset >= send_buf.size())
 		{
-			disconnect_client_during_iterator_walk(server, iterator);
+			disconnect_client(server, client.fd);
 			continue;
 		}
-		++iterator;
+		++i;
 	}
 }
 
@@ -94,25 +109,4 @@ static void	update_send_buffer_and_offset(std::string &send_buf, size_t &offset,
 		send_buf.erase(0, offset);
 		offset = 0;
 	}
-}
-
-// WARN: Should check if this function is working as intended...
-static void	disconnect_client_during_iterator_walk(t_IRC_Server &server,
-                std::unordered_map<int, t_IRC_Client>::iterator &iterator)
-{
-	int	fd = iterator->second.fd;
-	// WARN: handle close() failure?
-	close(fd);
-
-	// erases the client object from the unordered_map, but returns and assigns
-	// the next valid iterator for the map
-	iterator = server.clients.erase(iterator);
-
-	// cleans up the corresponding poll_fd key in the vector
-	std::erase_if(server.poll_fds, [fd](const pollfd& pfd){ return pfd.fd == fd; });
-
-	std::cout
-		<< "Client disconnected.\n"
-		"total number of clients: " << server.clients.size()
-		<< std::endl;
 }

--- a/src/sender.cpp
+++ b/src/sender.cpp
@@ -49,9 +49,7 @@ void	send_messages_to_all_clients(t_IRC_Server &server)
 				}
 				else if (errno == EWOULDBLOCK)
 				{
-					// WARN: This check might be an issue, because of evaluation
-					// sheet bullet point that could be misinterpreted...
-					// Discuss this with the team on Thursday.
+					// WARN: Discuss this with teammates on the next meeting.
 
 					// identical to EAGAIN.
 					// This occurs for non-blocking sockets, "if space is not available

--- a/src/sender.cpp
+++ b/src/sender.cpp
@@ -9,9 +9,12 @@
 #include <cstring> // for std::strerror()
 #include <cerrno>
 #include <iostream>
+#include <exception>
 
 static void	disconnect_client_during_iterator_walk(t_IRC_Server &server, int fd,
                 std::unordered_map<int, t_IRC_Client>::iterator &iterator);
+static void	update_send_buffer_and_offset(std::string &send_buf, size_t &offset,
+                const size_t sent_bytes);
 
 void	send_messages_to_all_clients(t_IRC_Server &server)
 {
@@ -25,7 +28,7 @@ void	send_messages_to_all_clients(t_IRC_Server &server)
 
 		t_IRC_Client	&client = iterator->second;
 		std::string		&send_buf = client.send_message_buffer;
-		if (send_buf.empty()) // no bytes to send to this client
+		if (client.send_offset >= send_buf.size()) // no bytes to send to this client
 		{
 			if (!is_flag_set(client.state, t_IRC_Client::DISCONNECT))
 				++iterator;
@@ -33,7 +36,8 @@ void	send_messages_to_all_clients(t_IRC_Server &server)
 				disconnect_client_during_iterator_walk(server, client.fd, iterator);
 			continue;
 		}
-		ret = send(client.fd, send_buf.c_str(), send_buf.size(), 0);
+		ret = send(client.fd, send_buf.c_str() + client.send_offset,
+			 send_buf.size() - client.send_offset, 0);
 		if (ret == -1)
 		{
 			log_error(std::strerror(errno), __FILE__, __LINE__, 0);
@@ -56,15 +60,41 @@ void	send_messages_to_all_clients(t_IRC_Server &server)
 				return;
 			}
 		}
-		send_buf.erase(0, ret);
-
-		if (is_flag_set(client.state, t_IRC_Client::DISCONNECT) && send_buf.empty())
+		try {
+			update_send_buffer_and_offset(send_buf, client.send_offset, ret);
+		} catch (const std::exception &e) {
+			log_error(e.what(), __FILE__, __LINE__, 1);
+			// WARN: Should an error message be sent to all clients? This exception
+			// is most probably an std::bad_alloc, which is fatal...
+			requested_shutdown = 1;
+			return;
+		}
+		if (is_flag_set(client.state, t_IRC_Client::DISCONNECT)
+			&& client.send_offset >= send_buf.size())
 		{
 			disconnect_client_during_iterator_walk(server, client.fd, iterator);
 			continue;
 		}
-
 		++iterator;
+	}
+}
+
+// std::string's erase() and clear() may throw std::bad_alloc
+static void	update_send_buffer_and_offset(std::string &send_buf, size_t &offset,
+                const size_t sent_bytes)
+{
+	size_t	buf_size = send_buf.size();
+
+	offset += sent_bytes;
+	if (offset >= buf_size)
+	{
+		send_buf.clear();
+		offset = 0;
+	}
+	else if (offset >= t_IRC_Client::offset_threshold && offset >= buf_size / 2)
+	{
+		send_buf.erase(0, offset);
+		offset = 0;
 	}
 }
 

--- a/src/sender.cpp
+++ b/src/sender.cpp
@@ -11,7 +11,7 @@
 #include <iostream>
 #include <exception>
 
-static void	disconnect_client_during_iterator_walk(t_IRC_Server &server, int fd,
+static void	disconnect_client_during_iterator_walk(t_IRC_Server &server,
                 std::unordered_map<int, t_IRC_Client>::iterator &iterator);
 static void	update_send_buffer_and_offset(std::string &send_buf, size_t &offset,
                 const size_t sent_bytes);
@@ -21,11 +21,8 @@ void	send_messages_to_all_clients(t_IRC_Server &server)
 	ssize_t	ret;
 
 	for (std::unordered_map<int, t_IRC_Client>::iterator iterator = server.clients.begin();
-		iterator != server.clients.end(); )
+		iterator != server.clients.end() && !requested_shutdown; )
 	{
-		if (requested_shutdown)
-			return;
-
 		t_IRC_Client	&client = iterator->second;
 		std::string		&send_buf = client.send_message_buffer;
 		if (client.send_offset >= send_buf.size()) // no bytes to send to this client
@@ -33,7 +30,7 @@ void	send_messages_to_all_clients(t_IRC_Server &server)
 			if (!is_flag_set(client.state, t_IRC_Client::DISCONNECT))
 				++iterator;
 			else
-				disconnect_client_during_iterator_walk(server, client.fd, iterator);
+				disconnect_client_during_iterator_walk(server, iterator);
 			continue;
 		}
 		ret = send(client.fd, send_buf.c_str() + client.send_offset,
@@ -51,7 +48,7 @@ void	send_messages_to_all_clients(t_IRC_Server &server)
 				// or by some socket flags), the kernel instead reports the error via:
 				// send() → -1
 				// errno = EPIPE
-				disconnect_client_during_iterator_walk(server, client.fd, iterator);
+				disconnect_client_during_iterator_walk(server, iterator);
 				continue;
 			}
 			else
@@ -72,7 +69,7 @@ void	send_messages_to_all_clients(t_IRC_Server &server)
 		if (is_flag_set(client.state, t_IRC_Client::DISCONNECT)
 			&& client.send_offset >= send_buf.size())
 		{
-			disconnect_client_during_iterator_walk(server, client.fd, iterator);
+			disconnect_client_during_iterator_walk(server, iterator);
 			continue;
 		}
 		++iterator;
@@ -99,9 +96,10 @@ static void	update_send_buffer_and_offset(std::string &send_buf, size_t &offset,
 }
 
 // WARN: Should check if this function is working as intended...
-static void	disconnect_client_during_iterator_walk(t_IRC_Server &server, int fd,
+static void	disconnect_client_during_iterator_walk(t_IRC_Server &server,
                 std::unordered_map<int, t_IRC_Client>::iterator &iterator)
 {
+	int	fd = iterator->second.fd;
 	// WARN: handle close() failure?
 	close(fd);
 

--- a/src/sender.cpp
+++ b/src/sender.cpp
@@ -71,8 +71,6 @@ void	send_messages_to_all_clients(t_IRC_Server &server)
 				update_send_buffer_and_offset(send_buf, client.send_offset, ret);
 			} catch (const std::exception &e) {
 				log_error(e.what(), __FILE__, __LINE__, 1);
-				// WARN: Should an error message be sent to all clients? This exception
-				// is most probably an std::bad_alloc, which is fatal...
 				requested_shutdown = 1;
 				return;
 			}

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -123,7 +123,7 @@ void	server_loop(t_IRC_Server &server)
 			}
 		}
 
-		// poll loop
+		// pollin event loop
 		for (size_t i = 0; i < server.poll_fds.size(); )
 		{
 			if (requested_shutdown)


### PR DESCRIPTION
- Fixes issue with incomplete commands interpreted as complete ones (`p` and `pa` were interpreted as `pass`)
- Adds handling of leading spaces in received string
- Handles messages with only spaces
- Adds handling of malformed client messages that include null bytes
- Sending messages is now more robust, checking for `POLLOUT` before sending messages
- Adds support for `SIGPIPE` handling, by allowing the `send()` function avoid `SIGPIPE`, informing `errno` of a broken socket
- Lightens the hard-coded nature of the allowed nickname symbols. A whitelist for those is introduced in the main header file, allowing to easily make changes in the future.
- Avoids undefined behavior when calling cctype's `std::isdigit()`, by casting the character to `unsigned char`.
- Adds first draft of `QUIT` command's implementation - should be reviewed once channels are introduced.
- Improves efficiency of send buffer cleanup, by adding an offset value, clearing up the buffer only when it gets big and most of it has been already consumed.