### PR TITLE
Message Parsing(fix): Important bug fix, where a forgotten ampersand …

### DIFF
--- a/src/msg_parser.cpp
+++ b/src/msg_parser.cpp
@@ -95,8 +95,9 @@ void	handle_message_to_discard(t_IRC_Client &client, const char *buf,
 		// append the trailing part after the newline
 		if (pos < received - 1) // otherwise, there is nothing to append.
 		{
+			ssize_t	len = received - pos - 1;
 			try {
-				msg.append(buf[pos + 1], received - pos - 1);
+				msg.append(&buf[pos + 1], static_cast<size_t>(len));
 			} catch (const std::exception &e) {
 				log_error(e.what(), __FILE__, __LINE__, 1);
 				requested_shutdown = 1;

--- a/src/msg_parser.cpp
+++ b/src/msg_parser.cpp
@@ -3,11 +3,6 @@
 // with 'nc'?), and inputting something and then ctrl + d twice in a row just
 // completely seems to break the server? This needs more testing. Is it SIGPIPE?
 
-// FIXME: delete this warning if you end up handling the null-terminators here.
-// WARN: Should the parser check for null-terminators - that are not 'supposed'
-// to be sent by an IRC client, but that may still be sent, as part of an attack
-// for example?
-
 #include "../lib/irc_fatstruct.hpp"
 #include "../lib/parser.hpp"
 #include "../lib/server.hpp"


### PR DESCRIPTION
I got to test the null terminator handling on Linux machines today, sending null bytes via netcat, by piping `printf` with a complex input into `nc`.
This led me to find this mistake :
The forgotten ampersand lets the compiler choose the overload which takes in a `character` and a count `n`, appending that character `n` times. Not what I had in mind the first time around...