### PR TITLE
Fix: Hostname Initialization

### DIFF
--- a/lib/irc_fatstruct.hpp
+++ b/lib/irc_fatstruct.hpp
@@ -171,7 +171,7 @@ typedef struct	s_IRC_Client
 	char				nick_buf[max_nicklen]; // not nullterminated, use 'nick' instead
 	std::string			username;
 	std::string			realname;
-	char				hostname[INET_ADDRSTRLEN]; // This array is null terminated when initialized by inet_ntop(). Change macro to 'INET6_ADDRSTRLEN' if server ever switches to TCP6 ('AF_INET6').
+	char				hostname[INET_ADDRSTRLEN]; // null terminated when initialized by inet_ntop(), or, by default, when set to "unknown\0". Change macro to 'INET6_ADDRSTRLEN' if server ever switches to TCP6 ('AF_INET6').
 	std::string			received_message_buffer;
 	std::string			send_message_buffer;
 	size_t				send_offset;

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -1,6 +1,27 @@
 #include <iostream>
+#include <cstring> // for std::memmove() and std::strerror()
 #include "../lib/server.hpp"
 #include "../lib/irc_fatstruct.hpp"
+
+static void	initialize_hostname(t_IRC_Client &client)
+{
+	if (!inet_ntop(AF_INET, &client.addr.sin_addr, client.hostname, INET_ADDRSTRLEN))
+	{
+		if (errno == EAFNOSUPPORT)
+			log_error("Failure to initialize hostname; "
+			"client's address is neither AF_INET nor AF_IFNET6. "
+			 "Setting as 'unknown'.",
+			 __FILE__, __LINE__, 0);
+		else
+			log_error("Failure to initialize hostname; "
+			"Size provided for string conversion is insufficient. "
+			"Setting as 'unkonwn'.",
+			 __FILE__, __LINE__, 0);
+
+		// sizeof() includes a '\0', making the array safe for appending
+		(void)std::memmove(client.hostname, "unknown", sizeof("unknown"));
+	}
+}
 
 static bool	setup_client(t_IRC_Server &server, int client_fd, struct sockaddr_in const &client_addr)
 {
@@ -30,23 +51,7 @@ static bool	setup_client(t_IRC_Server &server, int client_fd, struct sockaddr_in
 	* client side. */
 	client.nick_buf[0] = '*';
 	client.nick = std::string_view{client.nick_buf, 1};
-
-	// initialize hostname
-	if (!inet_ntop(AF_INET, &client_addr.sin_addr, client.hostname, INET_ADDRSTRLEN))
-	{
-		if (errno == EAFNOSUPPORT)
-			log_error("Failure to initialize hostname; "
-			"client's address is neither AF_INET nor AF_IFNET6",
-			 __FILE__, __LINE__, 0);
-		else
-			log_error("Failure to initialize hostname; "
-			"Size provided for string conversion is insufficient",
-			 __FILE__, __LINE__, 0);
-
-		disconnect_client(server, client.fd);
-		requested_shutdown = 1; //NOTE: Is this too heavyhanded here?
-		return false;
-	}
+	initialize_hostname(client);
 
 	return true;
 }


### PR DESCRIPTION
Failure of hostname initialization sets it to 'unknown' and keeps server alive.

WARN: This branch was branched out of an ongoing pull request: feature(non_blocking).
The latter should be first merged to main, and I will rebase this current PR's branch, once the merge happens.