### PR TITLE
Unified Error Handling

### DIFF
--- a/lib/irc_fatstruct.hpp
+++ b/lib/irc_fatstruct.hpp
@@ -212,7 +212,7 @@ bool	is_flag_set(const t_bmask state, const unsigned int mask);
 
 /* Error logging */
 void	log_error(const char *error, const char *context, const char *filename,
-            int line_num);
+            const int line_num);
 void	set_fatal_error_flag_and_log(t_bmask &state, const char *context,
             const char *filename, const int line_num);
 

--- a/lib/irc_fatstruct.hpp
+++ b/lib/irc_fatstruct.hpp
@@ -213,5 +213,7 @@ bool	is_flag_set(const t_bmask state, const unsigned int mask);
 /* Error logging */
 void	log_error(const char *error, const char *context, const char *filename,
             int line_num);
+void	set_fatal_error_flag_and_log(t_bmask &state, const char *context,
+            const char *filename, const int line_num);
 
 #endif//IRC_FATSTRUCT_HPP

--- a/lib/irc_fatstruct.hpp
+++ b/lib/irc_fatstruct.hpp
@@ -209,5 +209,6 @@ bool	is_flag_set(const t_bmask state, const unsigned int mask);
 /* Error logging */
 void	log_error(const char *error, const char *context, const char *filename,
             int line_num);
+void	log_exception(const char *what);
 
 #endif//IRC_FATSTRUCT_HPP

--- a/lib/irc_fatstruct.hpp
+++ b/lib/irc_fatstruct.hpp
@@ -201,6 +201,10 @@ typedef struct	s_IRC_Server
 	t_IRC_Channel							channels[MAX_CHANNELS];
 	int										channel_count;
 	std::vector<pollfd>						poll_fds;
+
+	/* destructor */
+	~s_IRC_Server();
+
 }											t_IRC_Server;
 
 /* Bit mask utils */
@@ -209,6 +213,5 @@ bool	is_flag_set(const t_bmask state, const unsigned int mask);
 /* Error logging */
 void	log_error(const char *error, const char *context, const char *filename,
             int line_num);
-void	log_exception(const char *what);
 
 #endif//IRC_FATSTRUCT_HPP

--- a/lib/irc_fatstruct.hpp
+++ b/lib/irc_fatstruct.hpp
@@ -186,6 +186,10 @@ static_assert(sizeof(t_IRC_Client) <= 68*CACHE_LINE_SIZE," t_IRC_Client did not 
 // NOTE: 'static constexpr' within a struct does not increase struct's memory occupation: they are literals known at compile time.
 typedef struct	s_IRC_Server
 {
+	enum {
+		FATAL_ERROR = BIT(0)
+	};
+
 	t_bmask									state; //Not in use in this version
 	static constexpr const char				*name = "humble_server";
 	static constexpr int					poll_timeout = 1000;
@@ -203,7 +207,7 @@ typedef struct	s_IRC_Server
 bool	is_flag_set(const t_bmask state, const unsigned int mask);
 
 /* Error logging */
-void	log_error(const char *error, const char *filename, int line_number,
-            bool is_exception);
+void	log_error(const char *error, const char *context, const char *filename,
+            int line_num);
 
 #endif//IRC_FATSTRUCT_HPP

--- a/lib/parser.hpp
+++ b/lib/parser.hpp
@@ -21,8 +21,7 @@ int		parse_message(const size_t pos, const std::string &buf,
 void	tokenize_message(t_IRC_Client &client, const std::string_view msg);
 
 /* Parsing utils */
-int		init_password(const char *src, std::string_view &dest);
-ssize_t	strlen_printable_no_spaces(const char *str);
+size_t	validate_password_and_strlen(const char *str);
 char	to_uppercase(char c);
 size_t	skip_leading_spaces_and_check_for_empty_message(const std::string &buf,
             const size_t pos, const bool has_cr);

--- a/lib/server.hpp
+++ b/lib/server.hpp
@@ -14,8 +14,6 @@
 
 extern volatile sig_atomic_t requested_shutdown;
 
-void	shutdown_server(t_IRC_Server *server);
-
 void	create_listener(t_IRC_Server &server);
 
 void	server_loop(t_IRC_Server &server);

--- a/lib/server.hpp
+++ b/lib/server.hpp
@@ -14,8 +14,7 @@
 
 extern volatile sig_atomic_t requested_shutdown;
 
-void	fatal_server_error(const char* msg, int fd);
-int		shutdown_server(t_IRC_Server *server);
+void	shutdown_server(t_IRC_Server *server);
 
 void	create_listener(t_IRC_Server &server);
 

--- a/src/client.cpp
+++ b/src/client.cpp
@@ -1,5 +1,6 @@
 #include <iostream>
-#include <exception>
+#include <cstring> // std::strerror()
+#include <cerrno>
 #include <string_view>
 #include "../lib/irc_fatstruct.hpp"
 #include "../lib/server.hpp"
@@ -19,6 +20,7 @@ bool	recv_from_client(t_IRC_Server &server, int fd)
 	{
 		if (errno == EAGAIN || errno == EWOULDBLOCK)
 			return false; // no data ready -> try later
+		log_error(strerror(errno), "recv", __FILE__, __LINE__);
 		return true; // error -> disconnect
 	}
 
@@ -30,7 +32,6 @@ bool	recv_from_client(t_IRC_Server &server, int fd)
 	return false;
 }
 
-// WARN: Add try-catch block/s to handle potential exceptions from std::string's clear() and erase()
 void	handle_client_message(t_IRC_Client &client, t_IRC_Server &server)
 {
 	std::string	&buf = client.received_message_buffer;
@@ -57,40 +58,18 @@ void	handle_client_message(t_IRC_Client &client, t_IRC_Server &server)
 		}
 
 		if (parse_message(pos, buf, client) == -1)
-		{
-			try {
-				build_ERR_INPUTTOOLONG(client);
-			} catch (const std::exception &e) {
-				log_error(e.what(), __FILE__, __LINE__, 1);
-				requested_shutdown = 1;
-				return;
-			}
-		}
+			build_ERR_INPUTTOOLONG(client);
 
 		if (is_flag_set(client.state, t_IRC_Client::DISCARD_MSG)) // no need to dispatch
 			client.state &= ~t_IRC_Client::DISCARD_MSG;
 		else
-		{
-			try {
-				dispatch_client_command(client, server);
-			} catch (const std::exception &e) {
-				log_error(e.what(), __FILE__, __LINE__, 1);
-				requested_shutdown = 1;
-				return;
-			}
-		}
+			dispatch_client_command(client, server);
+
 		buf.erase(0, pos + 1);
 	}
 	if (buf.length() >= t_parser::buf_size)
 	{
-		try {
-			build_ERR_INPUTTOOLONG(client);
-		} catch (const std::exception &e) {
-			log_error(e.what(), __FILE__, __LINE__, 1);
-			requested_shutdown = 1;
-			return;
-
-		}
+		build_ERR_INPUTTOOLONG(client);
 		client.state |= t_IRC_Client::DISCARD_MSG;
 		buf.clear();
 		/* NOTE: If user sends an extremely long buffer with no newlines:

--- a/src/error.cpp
+++ b/src/error.cpp
@@ -1,21 +1,18 @@
-#include "../lib/server.hpp"
+#include "../lib/irc_fatstruct.hpp"
 #include <sys/socket.h>
-
+#include <unistd.h> // for close()
 #include <iostream> // for std::cerr and its insertion operator
 
-void	shutdown_server(t_IRC_Server *server)
+s_IRC_Server::~s_IRC_Server()
 {
-	if (!server)
-		return;
+	if (this->listen_fd >= 0)
+		close(this->listen_fd);
 
-	if (server->listen_fd >= 0)
-		close(server->listen_fd);
-
-	for (auto &[fd, client] : server->clients)
+	for (auto &[fd, client] : this->clients)
 		close(fd);
 
-	server->clients.clear();
-	server->poll_fds.clear();
+	// NOTE: No need to manually clear the std::vector and std::unordered_map
+	// containers: their own destructors will get called automatically.
 }
 
 /* When calling this function:
@@ -30,9 +27,4 @@ void	log_error(const char *error, const char *context, const char *filename,
 		<< "ERROR. " << context << ": " << error
 		<< " (file: " << filename << ", line: " << line_num << ')'
 		<< std::endl;
-}
-
-void	log_exception(const char *what)
-{
-	std::cerr << "Exception caught: " << what << std::endl;
 }

--- a/src/error.cpp
+++ b/src/error.cpp
@@ -28,3 +28,10 @@ void	log_error(const char *error, const char *context, const char *filename,
 		<< " (file: " << filename << ", line: " << line_num << ')'
 		<< std::endl;
 }
+
+void	set_fatal_error_flag_and_log(t_bmask &state, const char *context,
+            const char *filename, const int line_num)
+{
+	state |= t_IRC_Server::FATAL_ERROR;
+	log_error(std::strerror(errno), context, filename, line_num);
+}

--- a/src/error.cpp
+++ b/src/error.cpp
@@ -2,6 +2,8 @@
 #include <sys/socket.h>
 #include <unistd.h> // for close()
 #include <iostream> // for std::cerr and its insertion operator
+#include <cstring>  // for std::strerror()
+#include <cerrno>
 
 s_IRC_Server::~s_IRC_Server()
 {

--- a/src/error.cpp
+++ b/src/error.cpp
@@ -21,7 +21,7 @@ s_IRC_Server::~s_IRC_Server()
 * • 'filename': pass the macro '__FILE__'
 * • 'line_number': pass the macro '__LINE__' */
 void	log_error(const char *error, const char *context, const char *filename,
-            int line_num)
+            const int line_num)
 {
 	std::cerr
 		<< "ERROR. " << context << ": " << error

--- a/src/error.cpp
+++ b/src/error.cpp
@@ -3,16 +3,11 @@
 
 #include <iostream> // for std::cerr and its insertion operator
 
-void	fatal_server_error(const char* msg, int fd)
+void	shutdown_server(t_IRC_Server *server)
 {
-	std::perror(msg);
-	if (fd>=0)
-		close(fd);
-	exit(1);
-}
+	if (!server)
+		return;
 
-int	shutdown_server(t_IRC_Server *server)
-{
 	if (server->listen_fd >= 0)
 		close(server->listen_fd);
 
@@ -21,18 +16,18 @@ int	shutdown_server(t_IRC_Server *server)
 
 	server->clients.clear();
 	server->poll_fds.clear();
-	return 0;
 }
 
 /* When calling this function:
+* • 'error': Description of the failure. Where applicable, can just be std::strerror(errno)
+* • 'context': Name of function that failed (for example: "send", "fcntl")
 * • 'filename': pass the macro '__FILE__'
 * • 'line_number': pass the macro '__LINE__' */
-void	log_error(const char *error, const char *filename, int line_number,
-            bool is_exception)
+void	log_error(const char *error, const char *context, const char *filename,
+            int line_num)
 {
-	std::cerr << "ERROR: ";
-	if (is_exception)
-		std::cerr << "Exception caught: ";
-	std::cerr << error <<
-		" (file: " << filename << ", line: " << line_number << ')' << std::endl;
+	std::cerr
+		<< "ERROR. " << context << ": " << error
+		<< " (file: " << filename << ", line: " << line_num << ')'
+		<< std::endl;
 }

--- a/src/error.cpp
+++ b/src/error.cpp
@@ -31,3 +31,8 @@ void	log_error(const char *error, const char *context, const char *filename,
 		<< " (file: " << filename << ", line: " << line_num << ')'
 		<< std::endl;
 }
+
+void	log_exception(const char *what)
+{
+	std::cerr << "Exception caught: " << what << std::endl;
+}

--- a/src/listener.cpp
+++ b/src/listener.cpp
@@ -1,31 +1,25 @@
 #include "../lib/irc_fatstruct.hpp"
 #include "../lib/server.hpp"
 
-#include <cstring> // for std::strerror()
-#include <cerrno>
-
 void	create_listener(t_IRC_Server &server)
 {
 	server.listen_fd = socket(AF_INET, SOCK_STREAM, 0);
 	if (server.listen_fd < 0)
 	{
-		log_error(std::strerror(errno), "socket", __FILE__, __LINE__);
-		server.state |= server.FATAL_ERROR;
+		set_fatal_error_flag_and_log(server.state, "socket", __FILE__, __LINE__);
 		return;
 	}
 
 	if (fcntl(server.listen_fd, F_SETFL, O_NONBLOCK) < 0)
 	{
-		log_error(std::strerror(errno), "fcntl", __FILE__, __LINE__);
-		server.state |= server.FATAL_ERROR;
+		set_fatal_error_flag_and_log(server.state, "fcntl", __FILE__, __LINE__);
 		return;
 	}
 
 	int	opt = 1;
 	if (setsockopt(server.listen_fd, SOL_SOCKET, SO_REUSEADDR, &opt, sizeof(opt)) < 0)
 	{
-		log_error(std::strerror(errno), "setsockopt", __FILE__, __LINE__);
-		server.state |= server.FATAL_ERROR;
+		set_fatal_error_flag_and_log(server.state, "setsockopt", __FILE__, __LINE__);
 		return;
 	}
 
@@ -36,14 +30,10 @@ void	create_listener(t_IRC_Server &server)
 
 	if (bind(server.listen_fd, reinterpret_cast<sockaddr*>(&socket_addr), sizeof(socket_addr)) < 0)
 	{
-		log_error(std::strerror(errno), "bind", __FILE__, __LINE__);
-		server.state |= server.FATAL_ERROR;
+		set_fatal_error_flag_and_log(server.state, "bind", __FILE__, __LINE__);
 		return;
 	}
 
 	if (listen(server.listen_fd, MAX_PENDING_CONNECTIONS) < 0)
-	{
-		log_error(std::strerror(errno), "listen", __FILE__, __LINE__);
-		server.state |= server.FATAL_ERROR;
-	}
+		set_fatal_error_flag_and_log(server.state, "listen", __FILE__, __LINE__);
 }

--- a/src/listener.cpp
+++ b/src/listener.cpp
@@ -1,18 +1,33 @@
 #include "../lib/irc_fatstruct.hpp"
 #include "../lib/server.hpp"
 
+#include <cstring> // for std::strerror()
+#include <cerrno>
+
 void	create_listener(t_IRC_Server &server)
 {
 	server.listen_fd = socket(AF_INET, SOCK_STREAM, 0);
 	if (server.listen_fd < 0)
-		fatal_server_error("socket", -1);
+	{
+		log_error(std::strerror(errno), "socket", __FILE__, __LINE__);
+		server.state |= server.FATAL_ERROR;
+		return;
+	}
 
 	if (fcntl(server.listen_fd, F_SETFL, O_NONBLOCK) < 0)
-		fatal_server_error("fcntl", server.listen_fd);
+	{
+		log_error(std::strerror(errno), "fcntl", __FILE__, __LINE__);
+		server.state |= server.FATAL_ERROR;
+		return;
+	}
 
 	int	opt = 1;
 	if (setsockopt(server.listen_fd, SOL_SOCKET, SO_REUSEADDR, &opt, sizeof(opt)) < 0)
-		fatal_server_error("setsockopt", server.listen_fd);
+	{
+		log_error(std::strerror(errno), "setsockopt", __FILE__, __LINE__);
+		server.state |= server.FATAL_ERROR;
+		return;
+	}
 
 	sockaddr_in	socket_addr{};
 	socket_addr.sin_family = AF_INET;
@@ -20,8 +35,15 @@ void	create_listener(t_IRC_Server &server)
 	socket_addr.sin_port = htons(server.port);
 
 	if (bind(server.listen_fd, reinterpret_cast<sockaddr*>(&socket_addr), sizeof(socket_addr)) < 0)
-		fatal_server_error("bind", server.listen_fd);
+	{
+		log_error(std::strerror(errno), "bind", __FILE__, __LINE__);
+		server.state |= server.FATAL_ERROR;
+		return;
+	}
 
 	if (listen(server.listen_fd, MAX_PENDING_CONNECTIONS) < 0)
-		fatal_server_error("listen", server.listen_fd);
+	{
+		log_error(std::strerror(errno), "listen", __FILE__, __LINE__);
+		server.state |= server.FATAL_ERROR;
+	}
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -36,33 +36,23 @@ int main(int argc, char **argv)
 	sigaction(SIGINT, &sa, NULL);
 	sigaction(SIGTERM, &sa, NULL);
 
-	// NOTE: nothing can throw up to this point, but from here on out, multiple
-	// container allocators could throw
+	t_IRC_Server	server = {};
+
+	server.port = atoi(argv[1]); // WARN: should we add some error handling for this?
+	server.password = std::string_view{argv[2], password_len};
+
 	try {
-		t_IRC_Server	server = {};
-
-		server.port = atoi(argv[1]); // WARN: should we add some error handling to this?
-		server.password = std::string_view{argv[2], password_len};
-
-		try {
-			create_listener(server);
-			if (!is_flag_set(server.state, server.FATAL_ERROR) && !requested_shutdown)
-				server_loop(server);
-
-		} catch (const std::exception &e) {
-			log_exception(e.what());
-			server.state |= t_IRC_Server::FATAL_ERROR;
-		}
-		shutdown_server(&server);
-		// FATAL_ERROR flag may be set by a caught exception or by syscall failures
-		if (is_flag_set(server.state, server.FATAL_ERROR))
-			return 1;
+		create_listener(server);
+		if (!is_flag_set(server.state, server.FATAL_ERROR) && !requested_shutdown)
+			server_loop(server);
 
 	} catch (const std::exception &e) {
-		// 'server' did not fully construct, no need for manual cleanup
-		log_exception(e.what());
-		return 1;
+		std::cerr << "Exception caught: " << e.what() << std::endl;
+		server.state |= t_IRC_Server::FATAL_ERROR;
 	}
+	// FATAL_ERROR flag may be set by a caught exception or by syscall failures
+	if (is_flag_set(server.state, server.FATAL_ERROR))
+		return 1;
 	return 0;
 }
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,5 +1,6 @@
 #include <csignal>
 #include <iostream>
+#include <exception>
 #include "../lib/server.hpp"
 #include "../lib/irc_fatstruct.hpp"
 #include "../lib/parser.hpp"
@@ -20,16 +21,8 @@ int main(int argc, char **argv)
 		return 1;
 	}
 
-	struct sigaction sa = {};
-	sa.sa_handler = signal_handler;
-	sigemptyset(&sa.sa_mask);
-	sigaction(SIGINT, &sa, NULL);
-	sigaction(SIGTERM, &sa, NULL);
-
-	t_IRC_Server server = {};
-	server.port = atoi(argv[1]);
-
-	if (init_password(argv[2], server.password) == -1)
+	size_t	password_len = validate_password_and_strlen(argv[2]);
+	if (password_len <= 0)
 	{
 		std::cerr
 			<< "Password '" << argv[2] << "' is either empty or contains "
@@ -37,9 +30,34 @@ int main(int argc, char **argv)
 		return 1;
 	}
 
-	create_listener(server);
-	server_loop(server);
-	shutdown_server(&server);
+	struct sigaction sa = {};
+	sa.sa_handler = signal_handler;
+	sigemptyset(&sa.sa_mask);
+	sigaction(SIGINT, &sa, NULL);
+	sigaction(SIGTERM, &sa, NULL);
+
+	// NOTE: nothing can throw up to this point, but from here on out, multiple
+	// container allocators could throw
+	t_IRC_Server	*p_server = nullptr; // allows shutting server down after try-catch block
+	try {
+		t_IRC_Server server = {};
+		p_server = &server;
+		server.port = atoi(argv[1]); // WARN: should we add some error handling to this?
+		server.password = std::string_view{argv[2], password_len};
+
+		create_listener(server);
+		if (!is_flag_set(server.state, server.FATAL_ERROR) && !requested_shutdown)
+			server_loop(server);
+
+	} catch (const std::exception &e) {
+		std::cerr << "Exception caught: " << e.what() << std::endl;
+		if (p_server)
+			p_server->state |= t_IRC_Server::FATAL_ERROR;
+	}
+	shutdown_server(p_server);
+	// FATAL_ERROR flag may be set by a caught exception or by syscall failures
+	if (!p_server || is_flag_set(p_server->state, p_server->FATAL_ERROR))
+		return 1;
 	return 0;
 }
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -38,28 +38,35 @@ int main(int argc, char **argv)
 
 	// NOTE: nothing can throw up to this point, but from here on out, multiple
 	// container allocators could throw
-	t_IRC_Server	*p_server = nullptr; // allows shutting server down after try-catch block
 	try {
-		t_IRC_Server server = {};
-		p_server = &server;
+		t_IRC_Server	server = {};
+
 		server.port = atoi(argv[1]); // WARN: should we add some error handling to this?
 		server.password = std::string_view{argv[2], password_len};
 
-		create_listener(server);
-		if (!is_flag_set(server.state, server.FATAL_ERROR) && !requested_shutdown)
-			server_loop(server);
+		try {
+			create_listener(server);
+			if (!is_flag_set(server.state, server.FATAL_ERROR) && !requested_shutdown)
+				server_loop(server);
+
+		} catch (const std::exception &e) {
+			log_exception(e.what());
+			server.state |= t_IRC_Server::FATAL_ERROR;
+		}
+		shutdown_server(&server);
+		// FATAL_ERROR flag may be set by a caught exception or by syscall failures
+		if (is_flag_set(server.state, server.FATAL_ERROR))
+			return 1;
 
 	} catch (const std::exception &e) {
-		std::cerr << "Exception caught: " << e.what() << std::endl;
-		if (p_server)
-			p_server->state |= t_IRC_Server::FATAL_ERROR;
-	}
-	shutdown_server(p_server);
-	// FATAL_ERROR flag may be set by a caught exception or by syscall failures
-	if (!p_server || is_flag_set(p_server->state, p_server->FATAL_ERROR))
+		// 'server' did not fully construct, no need for manual cleanup
+		log_exception(e.what());
 		return 1;
+	}
 	return 0;
 }
+
+// WARN: should sending SIGINT to the program return 0 (which is the case currently)?
 
 /*
  * steps to establish connection:

--- a/src/msg_parser.cpp
+++ b/src/msg_parser.cpp
@@ -5,7 +5,6 @@
 
 #include "../lib/irc_fatstruct.hpp"
 #include "../lib/parser.hpp"
-#include "../lib/server.hpp"
 
 #include <string>
 #include <string_view>
@@ -91,13 +90,9 @@ void	handle_message_to_discard(t_IRC_Client &client, const char *buf,
 		if (pos < received - 1) // otherwise, there is nothing to append.
 		{
 			ssize_t	len = received - pos - 1;
-			try {
-				msg.append(&buf[pos + 1], static_cast<size_t>(len));
-			} catch (const std::exception &e) {
-				log_error(e.what(), __FILE__, __LINE__, 1);
-				requested_shutdown = 1;
-			}
+			msg.append(&buf[pos + 1], static_cast<size_t>(len));
 		}
+
 		// unset DISCARD_MSG flag
 		client.state &= ~t_IRC_Client::DISCARD_MSG;
 	}

--- a/src/parsing_utils.cpp
+++ b/src/parsing_utils.cpp
@@ -2,30 +2,18 @@
 
 #include <cctype> // for std::toupper() & std::iscntrl()
 #include <string>
-#include <string_view>
-
-int	init_password(const char *src, std::string_view &dest)
-{
-	ssize_t	len = strlen_printable_no_spaces(src);
-
-	if (len <= 0)
-		return (-1);
-
-	dest = std::string_view{src, static_cast<size_t>(len)};
-	return (0);
-}
 
 /* Return values:
  * • The length of the string
- * • -1 if any control characters or spaces are detected */
-ssize_t	strlen_printable_no_spaces(const char *str)
+ * • 0 if any control characters or spaces are detected */
+size_t	validate_password_and_strlen(const char *str)
 {
 	ssize_t	i = 0;
 
 	for ( ; str[i]; ++i)
 	{
 		if (std::iscntrl(static_cast<unsigned char>(str[i])) || str[i] == ' ')
-			return (-1);
+			return (0);
 	}
 	return (i);
 }

--- a/src/registration.cpp
+++ b/src/registration.cpp
@@ -3,11 +3,9 @@
 #include "../lib/commands.hpp"
 #include "../lib/numerics.hpp"
 #include "../lib/parser.hpp"
-#include "../lib/server.hpp"
 
 #include <string_view>
 #include <unordered_map>
-#include <exception>
 #include <string> // for std::string's append()
 #include <algorithm> // for std::min()
 #include <cctype> // for std::isdigit()
@@ -206,20 +204,12 @@ void	execute_USER_cmd(t_IRC_Client &client)
 	if (is_flag_set(client.state, t_IRC_Client::PSWD_FIRST))
 	{
 		std::string_view	*params = client.parser.params;
-		try {
-			client.username = "~"; // a prefix indicating that 'username' is set by the user.
-			client.username.append(params[0].substr(0, t_IRC_Client::userlen)); // silently trim any characters after userlen
-			client.realname = params[3];
-			/* as for parameters [1] & [2]: they are usually sent from the client
-			* as '0' and '*', respectively - but they do not really concern anything
-			* in the current scope, and the server can silently ignore these. */
-		} catch (const std::exception &e) {
-			// std::string often dynamically allocates and may fail
-			log_error(e.what(), __FILE__, __LINE__, 1);
-			client.state |= t_IRC_Client::DISCONNECT;
-			requested_shutdown = 1;
-			return;
-		}
+		client.username = "~"; // a prefix indicating that 'username' is set by the user.
+		client.username.append(params[0].substr(0, t_IRC_Client::userlen)); // silently trim any characters after userlen
+		client.realname = params[3];
+		/* as for parameters [1] & [2]: they are usually sent from the client
+		* as '0' and '*', respectively - but they do not really concern anything
+		* in the current scope, and the server can silently ignore these. */
 	}
 	// NOTE:
 	// Server requires passowrd, which means that the user HAS to provide

--- a/src/sender.cpp
+++ b/src/sender.cpp
@@ -6,14 +6,13 @@
 #include <string>
 #include <cstring> // for std::strerror()
 #include <cerrno>
-#include <exception>
 
 static void	update_send_buffer_and_offset(std::string &send_buf, size_t &offset,
                 const size_t sent_bytes);
 
 void	send_messages_to_all_clients(t_IRC_Server &server)
 {
-	for (size_t i = 0; i < server.poll_fds.size(); )
+	for (size_t i = 0; !requested_shutdown && i < server.poll_fds.size(); )
 	{
 		if (server.listen_fd == server.poll_fds[i].fd)
 		{
@@ -58,18 +57,13 @@ void	send_messages_to_all_clients(t_IRC_Server &server)
 
 					* Other failures are possible here, but they all mean bad
 					* things for the connection -> time to disconnect client */
-					log_error(std::strerror(errno), __FILE__, __LINE__, 0);
+					log_error(std::strerror(errno), "send", __FILE__, __LINE__);
 					disconnect_client(server, client.fd);
 				}
 				continue;
 			}
-			try {
-				update_send_buffer_and_offset(send_buf, client.send_offset, ret);
-			} catch (const std::exception &e) {
-				log_error(e.what(), __FILE__, __LINE__, 1);
-				requested_shutdown = 1;
-				return;
-			}
+
+			update_send_buffer_and_offset(send_buf, client.send_offset, ret);
 		}
 		if (client.send_offset < send_buf.size()) // indicate that we need to write to the client
 			server.poll_fds[i].events |= POLLOUT;

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -1,5 +1,7 @@
 #include <iostream>
 #include <cstring> // for std::memmove() and std::strerror()
+#include <cerrno>
+#include <exception>
 #include "../lib/server.hpp"
 #include "../lib/irc_fatstruct.hpp"
 
@@ -10,13 +12,13 @@ static void	initialize_hostname(t_IRC_Client &client)
 		if (errno == EAFNOSUPPORT)
 			log_error("Failure to initialize hostname; "
 			"client's address is neither AF_INET nor AF_IFNET6. "
-			 "Setting as 'unknown'.",
-			 __FILE__, __LINE__, 0);
+			"Setting as 'unknown'.",
+			"inet_ntop", __FILE__, __LINE__);
 		else
 			log_error("Failure to initialize hostname; "
 			"Size provided for string conversion is insufficient. "
 			"Setting as 'unkonwn'.",
-			 __FILE__, __LINE__, 0);
+			"inet_ntop", __FILE__, __LINE__);
 
 		// sizeof() includes a '\0', making the array safe for appending
 		(void)std::memmove(client.hostname, "unknown", sizeof("unknown"));
@@ -28,18 +30,28 @@ static bool	setup_client(t_IRC_Server &server, int client_fd, struct sockaddr_in
 	int	one = 1;
 	if (setsockopt(client_fd, IPPROTO_TCP, TCP_NODELAY, &one, sizeof(one)) < 0)
 	{
-		std::perror("setsockopt");
+		log_error(std::strerror(errno), "setsockopt", __FILE__, __LINE__);
 		close(client_fd);
 		return false;
 	}
 	if (fcntl(client_fd, F_SETFL, O_NONBLOCK) < 0)
 	{
-		std::perror("fcntl");
+		log_error(std::strerror(errno), "fcntl", __FILE__, __LINE__);
 		close(client_fd);
 		return false;
 	}
-	server.poll_fds.push_back(pollfd{client_fd, POLLIN, 0});
-	server.clients[client_fd] = t_IRC_Client{};
+
+	// WARN: both of the next calls may heap allocate via std::vector and std::unordered_map.
+	// These can throw exceptions, which previously would not be caught by our program.
+	// If either of those fails, the client_fd has to be closed here, as it might
+	// not have been integrated to the poll_fds vector.
+	try {
+		server.poll_fds.push_back(pollfd{client_fd, POLLIN, 0});
+		server.clients[client_fd] = t_IRC_Client{};
+	} catch (const std::exception &e) {
+		close(client_fd);
+		throw; // throws the same exception that was just caught
+	}
 
 	t_IRC_Client	&client = server.clients[client_fd];
 	client.fd = client_fd;
@@ -61,16 +73,18 @@ void	accept_new_client(t_IRC_Server &server)
 	sockaddr_in client_addr{};
 	socklen_t	client_addr_len = sizeof(client_addr);
 	int			client_fd = accept(server.listen_fd, (sockaddr*)&client_addr, &client_addr_len);
-	if (client_fd < 0 && (errno == EAGAIN || errno == EWOULDBLOCK))
-		return;
 	if (client_fd < 0)
 	{
-		std::perror("accept");
+		if (errno == EAGAIN || errno == EWOULDBLOCK)
+			return;
+		log_error(std::strerror(errno), "accept", __FILE__, __LINE__);
 		return;
 	}
 	if (server.clients.size() >= MAX_CLIENTS)
 	{
-		std::cout << "This server is full." << std::endl;
+		// WARN: Should this error be communicated to the client before disconnecting them?
+		// std::cout << "This server is full." << std::endl;
+		log_error("Server is full", "server", __FILE__, __LINE__);
 		close(client_fd);
 		return;
 	}
@@ -86,6 +100,9 @@ static bool	handle_poll_event(t_IRC_Server &server, int fd, short rev)
 	{
 		if (fd == server.listen_fd)
 		{
+			// WARN: What error log should be communicated in this case? Next line just a draft.
+			// log_error("Fatal failure", "listening socket", __FILE__, __LINE__);
+			server.state |= server.FATAL_ERROR;
 			requested_shutdown = 1;
 			return true;
 		}
@@ -131,6 +148,8 @@ void	server_loop(t_IRC_Server &server)
 				continue;
 			else
 			{
+				log_error(strerror(errno), "poll", __FILE__, __LINE__);
+				server.state |= server.FATAL_ERROR;
 				requested_shutdown = 1;
 				return ;
 			}


### PR DESCRIPTION
- Improves robustness of error handling
- Catches more c++ exceptions, without over-cluttering the code. Only two try-catch blocks in the whole code base
- Differentiates program return values: More fatal errors lead to a return value of 1
- Replaces shutdown_server() with a proper t_IRC_Server struct destructor, that is called automatically before main() returns.
- Ensures that internal containers’ destructors are always called, by always returning from main instead of exiting.
- Unifies error handling flow, using the log_error() function (with either a custom message or with std::strerror()).

Future things to discuss with the team and consider to implement:
- SIGINT currently leads to return 0. Is this what we want?
- Server full when a client tries to connect: Should the client be informed of that?
- atoi() of input port number: Should it be more robust?