### PR TITLE
Makefile(feat): Sanitizer rule + fix for multithreaded Make

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,7 @@ SRC		= src/main.cpp src/server.cpp src/listener.cpp src/client.cpp \
 		  src/command_utils.cpp
 OBJS	= $(SRC:.cpp=.o)
 DEPS	= $(SRC:.cpp=.d)
+SANS	= -fsanitize=address,undefined,leak
 
 all: $(NAME)
 
@@ -22,7 +23,11 @@ clean:
 fclean: clean
 	rm -f $(NAME)
 
-re: fclean all
+re: fclean
+	$(MAKE) CFLAGS="$(CFLAGS)" all
+
+fsan: CFLAGS += $(SANS)
+fsan: re
 
 -include $(DEPS)
 


### PR DESCRIPTION
- adds a sanitizer rule which is supported on both Linux and Mac
- Adjusts 're' rule, which the sanitizer rule runs, so that it is compatible with it
- adjustment of 're' rule also allows running make with multiple threads (using the `-j<n threads>` flag), which would otherwise break, since 're' had multiple dependencies which would run concurrently