### PR TITLE
Makefile(fix): Removes 'leak' fsanitize flag from Makefile (Mac does not support it)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ SRC		= src/main.cpp src/server.cpp src/listener.cpp src/client.cpp \
 		  src/command_utils.cpp
 OBJS	= $(SRC:.cpp=.o)
 DEPS	= $(SRC:.cpp=.d)
-SANS	= -fsanitize=address,undefined,leak
+SANS	= -fsanitize=address,undefined
 
 all: $(NAME)
 


### PR DESCRIPTION
Just noticed that Mac does not support this specific flag