### PR TITLE
Atoi() replacement: Robust error handling for input port

### DIFF
--- a/lib/irc_fatstruct.hpp
+++ b/lib/irc_fatstruct.hpp
@@ -6,6 +6,7 @@
 # include <poll.h>
 # include <unordered_map>
 # include <vector>
+# include <cstdint> // for fixed width integer data types
 # include <new> // for hardware_constructive_interference_size
 # include <string_view>
 
@@ -195,7 +196,7 @@ typedef struct	s_IRC_Server
 	static constexpr int					poll_timeout = 1000;
 	static constexpr const char				*version = "0.042"; // remember to update when upgrading ;-)
 	int										listen_fd;
-	int										port;
+	uint16_t								port;
 	std::string_view						password;
 	std::unordered_map<int, t_IRC_Client>	clients;
 	t_IRC_Channel							channels[MAX_CHANNELS];

--- a/lib/parser.hpp
+++ b/lib/parser.hpp
@@ -21,6 +21,7 @@ int		parse_message(const size_t pos, const std::string &buf,
 void	tokenize_message(t_IRC_Client &client, const std::string_view msg);
 
 /* Parsing utils */
+bool	convert_port_string_to_sixteen_bit_uint(std::string_view str, uint16_t &result);
 size_t	validate_password_and_strlen(const char *str);
 char	to_uppercase(char c);
 size_t	skip_leading_spaces_and_check_for_empty_message(const std::string &buf,

--- a/lib/parser.hpp
+++ b/lib/parser.hpp
@@ -3,6 +3,7 @@
 
 # include <string>
 # include <string_view>
+# include <cstdint>     // fixed width data types
 
 /* Forward declarations */
 struct	s_IRC_Server;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,6 +1,7 @@
 #include <csignal>
 #include <iostream>
 #include <exception>
+#include <limits> // std::numeric_limits
 #include "../lib/server.hpp"
 #include "../lib/irc_fatstruct.hpp"
 #include "../lib/parser.hpp"
@@ -21,6 +22,17 @@ int main(int argc, char **argv)
 		return 1;
 	}
 
+	uint16_t	port = 0;
+	if (!convert_port_string_to_sixteen_bit_uint(argv[1], port))
+	{
+		std::cerr
+			<< "Port \"" << argv[1] << "\" is invalid. Accepted range: 1 to "
+			<< std::numeric_limits<uint16_t>::max() << ", inclusive. "
+			"Only numeric characters are accepted."
+			<< std::endl;
+		return 1;
+	}
+
 	size_t	password_len = validate_password_and_strlen(argv[2]);
 	if (password_len <= 0)
 	{
@@ -38,7 +50,7 @@ int main(int argc, char **argv)
 
 	t_IRC_Server	server = {};
 
-	server.port = atoi(argv[1]); // WARN: should we add some error handling for this?
+	server.port = port;
 	server.password = std::string_view{argv[2], password_len};
 
 	try {

--- a/src/parsing_utils.cpp
+++ b/src/parsing_utils.cpp
@@ -1,7 +1,27 @@
 #include "../lib/parser.hpp"
 
-#include <cctype> // for std::toupper() & std::iscntrl()
+#include <cctype>       // for std::toupper() & std::iscntrl()
 #include <string>
+#include <string_view>
+#include <cstdint>      // for uint16_t data type
+#include <charconv>     // for std::from_chars() and std::from_chars_result
+#include <system_error> // for std::errc (from_chars() error codes)
+
+/* exception-free numeric parsing function.
+*  Accepts the range [1, UINT16_MAX] inclusive, suitable for a port.
+*  Rejects any non-numeric character. */
+bool	convert_port_string_to_sixteen_bit_uint(std::string_view str, uint16_t &result)
+{
+	std::from_chars_result	conversion_info =
+		std::from_chars(str.cbegin(), str.cend(), result);
+
+	if (conversion_info.ptr != str.cend() ||
+			conversion_info.ec == std::errc::invalid_argument ||
+			conversion_info.ec == std::errc::result_out_of_range ||
+			result == 0)
+		return false;
+	return true;
+}
 
 /* Return values:
  * • The length of the string

--- a/src/parsing_utils.cpp
+++ b/src/parsing_utils.cpp
@@ -3,7 +3,6 @@
 #include <cctype>       // for std::toupper() & std::iscntrl()
 #include <string>
 #include <string_view>
-#include <cstdint>      // for uint16_t data type
 #include <charconv>     // for std::from_chars() and std::from_chars_result
 #include <system_error> // for std::errc (from_chars() error codes)
 

--- a/src/parsing_utils.cpp
+++ b/src/parsing_utils.cpp
@@ -8,6 +8,7 @@
 
 /* exception-free numeric parsing function.
 *  Accepts the range [1, UINT16_MAX] inclusive, suitable for a port.
+*  Accepting port 0 would be asking from the kernel to grant any available port.
 *  Rejects any non-numeric character. */
 bool	convert_port_string_to_sixteen_bit_uint(std::string_view str, uint16_t &result)
 {


### PR DESCRIPTION
Received input argument for the listening port is now parsed in a way that rejects:
-  any unexpected non-numeric characters
- negative values*
- Values that overflow a sixteen bit unsigned integer's range*
- Zero**

* In the current main branch, negative values and values which overflow the range of a TCP port (always `uint16_t`) would still get interpreted as valid ports, because the `htons()` function that is used on those values casts them to uint16_t. This results in our server displaying a false positive: `server running at port <negative_port / overflow_port>`, which is not the actual port being used. This issue is now resolved.
** The 42 school assignment explicitly asks for the input port to be the one that the server listens on. Port zero asks from the kernel to grant the server an available port, so it would not match the input.

This commit was tested, also using the `netstat -an | grep LISTEN`, which displays the actual ports the machine is listening on.